### PR TITLE
Set paths correctly when loading newer versions

### DIFF
--- a/nvm.el
+++ b/nvm.el
@@ -7,7 +7,7 @@
 ;; Version: 0.1.0
 ;; Keywords: node, nvm
 ;; URL: http://github.com/rejeep/nvm.el
-;; Package-Requires: ((s "1.8.0") (dash "2.4.0") (f "0.14.0"))
+;; Package-Requires: ((s "1.8.0") (dash "2.4.0") (f "0.14.0") (dash-functional "2.4.0"))
 
 ;; This file is NOT part of GNU Emacs.
 
@@ -35,6 +35,7 @@
 (require 'f)
 (require 's)
 (require 'dash)
+(require 'dash-functional)
 
 (defgroup nvm nil
   "Manage Node versions within Emacs"
@@ -46,6 +47,9 @@
   "v[0-9]+\.[0-9]+\.[0-9]+"
   "Regex matching a Node version.")
 
+(defconst nvm-runtime-re
+  "\\(?:versions/node/\\|versions/io.js/\\)?")
+
 (defcustom nvm-dir (f-full "~/.nvm")
   "Full path to Nvm installation directory."
   :group 'nvm
@@ -54,35 +58,62 @@
 (defvar nvm-current-version nil
   "Current active version.")
 
+(defun nvm--using-new-path-schema? ()
+  (f-exists? (f-join nvm-dir "versions")))
+
 (defun nvm--installed-versions ()
   (let ((match-fn (lambda (directory)
-              (s-matches? (concat "^" nvm-version-re "$") (f-filename directory)))))
-    (--map (f-filename it)
-           (append
-            (f-directories nvm-dir match-fn)
-            (f-directories (f-join nvm-dir "versions" "node") match-fn)))))
+                    (s-matches? (concat nvm-version-re "$") (f-filename directory)))))
+    (-concat
+     (nvm--version-directories-new match-fn)
+     (nvm--version-directories-old match-fn))))
+
+(defun nvm--version-directories-old (match-fn)
+  (--map (list (f-filename it) it) (f-directories nvm-dir match-fn)))
+
+(defun nvm--clean-runtime-name (runtime)
+  (s-replace "io.js" "iojs" (f-filename runtime)))
+
+(defun nvm--version-name (runtime path)
+  "Makes runtime names match those in nvm ls"
+  (if (string= "node" runtime)
+      (f-filename path)
+    (concat (nvm--clean-runtime-name runtime) "-" (f-filename it))))
+
+(defun nvm--version-directories-new (match-fn)
+  (when (nvm--using-new-path-schema?))
+    (let ((runtime-options
+           (lambda (runtime)
+             (--map (list (nvm--version-name (f-filename runtime) it) it)
+                    (f-directories runtime match-fn)))))
+      (-flatten-n 1 (-map runtime-options (f-directories (f-join nvm-dir "versions"))))))
 
 (defun nvm--version-installed? (version)
   "Return true if VERSION is installed, false otherwise."
-  (-contains? (nvm--installed-versions) version))
+  (--any? (string= (car it) version) (nvm--installed-versions)))
 
 (defun nvm--find-exact-version-for (short)
   "Find most suitable version for SHORT.
 
 SHORT is a string containing major and minor version.  This
 function will return the most recent patch version."
-  (when (s-matches? "^v?[0-9]+\.[0-9]+\\(\.[0-9]+\\)?$" short)
-    (unless (s-starts-with? "v" short)
+  (when (s-matches? "v?[0-9]+\.[0-9]+\\(\.[0-9]+\\)?$" short)
+    (unless (or (s-starts-with? "v" short)
+                 (s-starts-with? "node" short)
+                 (s-starts-with? "iojs" short))
       (setq short (concat "v" short)))
-    (let ((versions (nvm--installed-versions)))
-      (if (--first (string= it short) versions)
-          short
+    (let* ((versions (nvm--installed-versions))
+           (first-version
+            (--first (string= (car it) short) versions)))
+      (if first-version
+          first-version
         (let ((possible-versions
                (-filter
                 (lambda (version)
-                  (s-starts-with? short version))
+                  (s-contains? short (car version)))
                 versions)))
-          (-min-by 'string< possible-versions))))))
+          (-min-by (-on 'string< (lambda (version) (car version)))
+                   possible-versions))))))
 
 (defun nvm-use (version &optional callback)
   "Activate Node VERSION.
@@ -90,25 +121,26 @@ function will return the most recent patch version."
 If CALLBACK is specified, active in that scope and then reset to
 previously used version."
   (setq version (nvm--find-exact-version-for version))
-  (if (nvm--version-installed? version)
-      (let ((prev-version nvm-current-version))
-        (setenv "NVM_BIN" (f-join nvm-dir version "bin"))
-        (setenv "NVM_PATH" (f-join nvm-dir version "lib" "node"))
-        (let* ((path-re (concat "^" (f-join nvm-dir nvm-version-re "bin") "/?$"))
-               (paths
-                (cons
-                 (f-full (f-join nvm-dir version "bin"))
-                 (-reject
-                  (lambda (path)
-                    (s-matches? path-re path))
-                  (parse-colon-path (getenv "PATH"))))))
-          (setenv "PATH" (s-join path-separator paths)))
-        (setq nvm-current-version version)
-        (when callback
-          (unwind-protect
-              (funcall callback)
-            (when prev-version (nvm-use prev-version)))))
-    (error "No such version %s" version)))
+  (let ((version-path (-last-item version)))
+    (if (nvm--version-installed? (car version))
+        (let ((prev-version nvm-current-version))
+          (setenv "NVM_BIN" (f-join version-path "bin"))
+          (setenv "NVM_PATH" (f-join version-path "lib" "node"))
+          (let* ((path-re (concat "^" (f-join nvm-dir nvm-runtime-re) nvm-version-re "/bin/?$"))
+                 (paths
+                  (cons
+                   (f-full (f-join version-path "bin"))
+                   (-reject
+                    (lambda (path)
+                      (s-matches? path-re path))
+                    (parse-colon-path (getenv "PATH"))))))
+            (setenv "PATH" (s-join path-separator paths)))
+          (setq nvm-current-version version)
+          (when callback
+            (unwind-protect
+                (funcall callback)
+              (when prev-version (nvm-use (car prev-version))))))
+      (error "No such version %s" version))))
 
 (defun nvm-use-for (&optional path callback)
   "Activate Node for PATH or `default-directory'.

--- a/test/nvm-test.el
+++ b/test/nvm-test.el
@@ -9,7 +9,21 @@
   (should-have-env "NVM_PATH" (f-join nvm-dir version "lib" "node"))
   (should-have-env "PATH" (concat (f-full (f-join nvm-dir version "bin")) ":/path/to/foo/bin/:/path/to/bar/bin/")))
 
-
+(defun should-use-new-version (runtime version)
+  (should-have-env "NVM_BIN" (f-join nvm-dir "versions" runtime version "bin"))
+  (should-have-env "NVM_PATH" (f-join nvm-dir "versions" runtime version "lib" "node"))
+  (should-have-env "PATH" (concat (f-full (f-join nvm-dir "versions" runtime version "bin")) ":/path/to/foo/bin/:/path/to/bar/bin/")))
+
+(defun stub-old-tuples-for (versions)
+  (let ((as-tuple (lambda (version)
+                    (list version (concat "/path/to/nvm/" version)))))
+    (cl-map #'list as-tuple versions)))
+
+(defun stub-new-tuples-for (vr-tuples)
+  (let ((as-tuple (lambda (vr)
+                    (list (car vr) (concat "/path/to/nvm/versions/" (car (cdr vr)) "/" (car vr))))))
+    (cl-map #'list as-tuple vr-tuples)))
+
 ;;;; nvm-use
 
 (ert-deftest nvm-use-test/version-not-available ()
@@ -18,13 +32,27 @@
 
 (ert-deftest nvm-use-test/version-available-no-callback ()
   (with-sandbox
-   (stub nvm--installed-versions => '("v0.10.1"))
+   (stub nvm--installed-versions => (stub-old-tuples-for '("v0.10.1")))
    (nvm-use "v0.10.1")
    (should-use-version "v0.10.1")))
 
+(ert-deftest nvm-use-test/version-new-directory-style-no-callback ()
+  (with-sandbox
+   (stub nvm--installed-versions =>
+         (stub-new-tuples-for '(("v4.0.0" "node") ("iojs-v3.3.0" "io.js"))))
+   (nvm-use "v4.0.0")
+   (should-use-new-version "node" "v4.0.0")))
+
+(ert-deftest nvm-use-test/version-new-directory-iojs-style-no-callback ()
+  (with-sandbox
+   (stub nvm--installed-versions =>
+         (stub-new-tuples-for '(("v4.0.0" "node") ("v3.3.0" "io.js"))))
+   (nvm-use "v3.3.0")
+   (should-use-new-version "io.js" "v3.3.0")))
+
 (ert-deftest nvm-use-test/version-available-with-callback ()
   (with-sandbox
-   (stub nvm--installed-versions => '("v0.8.2" "v0.10.1"))
+   (stub nvm--installed-versions => (stub-old-tuples-for '("v0.8.2" "v0.10.1")))
    (nvm-use "v0.8.2")
    (should-use-version "v0.8.2")
    (nvm-use "v0.10.1"
@@ -34,7 +62,7 @@
 
 (ert-deftest nvm-use-test/version-available-with-callback-that-errors ()
   (with-sandbox
-   (stub nvm--installed-versions => '("v0.8.2" "v0.10.1"))
+   (stub nvm--installed-versions => (stub-old-tuples-for '("v0.8.2" "v0.10.1")))
    (nvm-use "v0.8.2")
    (should-use-version "v0.8.2")
    (should-error
@@ -43,7 +71,7 @@
 
 (ert-deftest nvm-use-test/version-available-with-callback-that-errors-no-previous ()
   (with-sandbox
-   (stub nvm--installed-versions => '("v0.8.2" "v0.10.1"))
+   (stub nvm--installed-versions => (stub-old-tuples-for '("v0.8.2" "v0.10.1")))
    ;; NOTE: We are not actually testing what we say we are. It's hard
    ;; to do because the error we are expecting is a
    ;; 'wrong-type-argument error, but the callback error is the one
@@ -58,11 +86,10 @@
 
 (ert-deftest nvm-use-test/short-version ()
   (with-sandbox
-   (stub nvm--installed-versions => '("v0.10.1"))
+   (stub nvm--installed-versions => (stub-old-tuples-for '("v0.10.1")))
    (nvm-use "0.10")
    (should-use-version "v0.10.1")))
 
-
 ;;;; nvm-use-for
 
 (ert-deftest nvm-use-for-test/no-config ()
@@ -73,21 +100,21 @@
 (ert-deftest nvm-use-for-test/config-no-such-version ()
   (with-sandbox
    (write-nvmrc "v0.10.1")
-   (stub nvm--installed-versions => '("v0.8.2"))
+   (stub nvm--installed-versions => (stub-old-tuples-for '("v0.8.2")))
    (should-error
     (nvm-use-for nvm-test/sandbox-path))))
 
 (ert-deftest nvm-use-for-test/config-no-callback ()
   (with-sandbox
    (write-nvmrc "v0.10.1")
-   (stub nvm--installed-versions => '("v0.8.2" "v0.10.1"))
+   (stub nvm--installed-versions => (stub-old-tuples-for '("v0.8.2" "v0.10.1")))
    (nvm-use-for nvm-test/sandbox-path)
    (should-use-version "v0.10.1")))
 
 (ert-deftest nvm-use-for-test/config-callback ()
   (with-sandbox
    (write-nvmrc "v0.10.1")
-   (stub nvm--installed-versions => '("v0.8.2" "v0.10.1"))
+   (stub nvm--installed-versions => (stub-old-tuples-for '("v0.8.2" "v0.10.1")))
    (nvm-use "v0.8.2")
    (should-use-version "v0.8.2")
    (nvm-use-for nvm-test/sandbox-path
@@ -98,41 +125,42 @@
 (ert-deftest nvm-use-for-test/no-path ()
   (with-sandbox
    (write-nvmrc "v0.8.2")
-   (stub nvm--installed-versions => '("v0.8.2"))
+   (stub nvm--installed-versions => (stub-old-tuples-for '("v0.8.2")))
    (nvm-use-for)
    (should-use-version "v0.8.2")))
 
 (ert-deftest nvm-use-for-test/short-version ()
   (with-sandbox
    (write-nvmrc "v0.10")
-   (stub nvm--installed-versions => '("v0.8.2" "v0.10.1"))
+   (stub nvm--installed-versions => (stub-old-tuples-for '("v0.8.2" "v0.10.1")))
    (nvm-use-for nvm-test/sandbox-path)
    (should-use-version "v0.10.1")))
 
 (ert-deftest nvm-use-for-test/newlines ()
   (with-sandbox
    (write-nvmrc "\nv0.10\n")
-   (stub nvm--installed-versions => '("v0.8.2" "v0.10.1"))
+   (stub nvm--installed-versions => (stub-old-tuples-for '("v0.8.2" "v0.10.1")))
    (nvm-use-for nvm-test/sandbox-path)
    (should-use-version "v0.10.1")))
 
-
 ;;;; nvm--find-exact-version-for
 
 (ert-deftest nvm--find-exact-version-for-test ()
   (with-mock
-   (stub nvm--installed-versions => '("v0.8.2" "v0.8.8" "v0.6.0" "v0.10.7" "v0.10.2"))
+   (stub
+    nvm--installed-versions =>
+    (stub-old-tuples-for '("v0.8.2" "v0.8.8" "v0.6.0" "v0.10.7" "v0.10.2")))
    (should-not (nvm--find-exact-version-for "0"))
    (should-not (nvm--find-exact-version-for "v0"))
    (should-not (nvm--find-exact-version-for "0.3"))
    (should-not (nvm--find-exact-version-for "v0.6.1"))
    (should-not (nvm--find-exact-version-for "v0.6.0.1"))
    (should-not (nvm--find-exact-version-for "merry christmas"))
-   (should (string= (nvm--find-exact-version-for "v0.6.0") "v0.6.0"))
-   (should (string= (nvm--find-exact-version-for "v0.8.2") "v0.8.2"))
-   (should (string= (nvm--find-exact-version-for "v0.10.7") "v0.10.7"))
-   (should (string= (nvm--find-exact-version-for "v0.6") "v0.6.0"))
-   (should (string= (nvm--find-exact-version-for "0.8") "v0.8.8"))
-   (should (string= (nvm--find-exact-version-for "v0.8") "v0.8.8"))
-   (should (string= (nvm--find-exact-version-for "v0.10") "v0.10.7"))
-   (should (string= (nvm--find-exact-version-for "0.10") "v0.10.7"))))
+   (should (string= (car (nvm--find-exact-version-for "v0.6.0")) "v0.6.0"))
+   (should (string= (car (nvm--find-exact-version-for "v0.8.2")) "v0.8.2"))
+   (should (string= (car (nvm--find-exact-version-for "v0.10.7")) "v0.10.7"))
+   (should (string= (car (nvm--find-exact-version-for "v0.6")) "v0.6.0"))
+   (should (string= (car (nvm--find-exact-version-for "0.8")) "v0.8.8"))
+   (should (string= (car (nvm--find-exact-version-for "v0.8")) "v0.8.8"))
+   (should (string= (car (nvm--find-exact-version-for "v0.10")) "v0.10.7"))
+   (should (string= (car (nvm--find-exact-version-for "0.10")) "v0.10.7"))))

--- a/test/test-helper.el
+++ b/test/test-helper.el
@@ -27,4 +27,5 @@
 
 (require 'ert)
 (require 'el-mock)
+(require 'cl-lib)
 (require 'nvm (f-expand "nvm" nvm-test/root-path))


### PR DESCRIPTION
When loading newer versions, installed under `NVM_HOME/versions`, the paths weren't being set correctly, as the code still built them assuming everything fell under `NVM_HOME`. This pull request fixes that, and also enables loading io.js versions.