### PR TITLE
Add NVM_BIN to exec-path

### DIFF
--- a/nvm.el
+++ b/nvm.el
@@ -115,6 +115,7 @@ function will return the most recent patch version."
           (-min-by (-on 'string< (lambda (version) (car version)))
                    possible-versions))))))
 
+;;;###autoload
 (defun nvm-use (version &optional callback)
   "Activate Node VERSION.
 
@@ -142,6 +143,7 @@ previously used version."
               (when prev-version (nvm-use (car prev-version))))))
       (error "No such version %s" version))))
 
+;;;###autoload
 (defun nvm-use-for (&optional path callback)
   "Activate Node for PATH or `default-directory'.
 

--- a/nvm.el
+++ b/nvm.el
@@ -137,14 +137,12 @@ previously used version."
                       (s-matches? path-re path))
                     (parse-colon-path (getenv "PATH"))))))
             (setenv "PATH" (s-join path-separator paths))
-            (unless callback
-              (setq exec-path (cons new-bin-path (--remove (s-matches? path-re it) exec-path)))))
+            (setq exec-path (cons new-bin-path (--remove (s-matches? path-re it) exec-path))))
           (setq nvm-current-version version)
           (when callback
-            (let ((exec-path (cons new-bin-path (--remove (s-matches? path-re it) exec-path))))
-              (unwind-protect
-                  (funcall callback)
-                (when prev-version (nvm-use (car prev-version)))))))
+            (unwind-protect
+                (funcall callback)
+              (when prev-version (nvm-use (car prev-version))))))
       (error "No such version %s" version))))
 
 ;;;###autoload

--- a/nvm.el
+++ b/nvm.el
@@ -124,7 +124,8 @@ previously used version."
   (setq version (nvm--find-exact-version-for version))
   (let ((version-path (-last-item version)))
     (if (nvm--version-installed? (car version))
-        (let ((prev-version nvm-current-version))
+        (let ((prev-version nvm-current-version)
+              (prev-exec-path exec-path))
           (setenv "NVM_BIN" (f-join version-path "bin"))
           (setenv "NVM_PATH" (f-join version-path "lib" "node"))
           (let* ((path-re (concat "^" (f-join nvm-dir nvm-runtime-re) nvm-version-re "/bin/?$"))
@@ -142,7 +143,8 @@ previously used version."
           (when callback
             (unwind-protect
                 (funcall callback)
-              (when prev-version (nvm-use (car prev-version))))))
+              (when prev-version (nvm-use (car prev-version)))
+              (setq exec-path prev-exec-path))))
       (error "No such version %s" version))))
 
 ;;;###autoload

--- a/test/nvm-test.el
+++ b/test/nvm-test.el
@@ -7,12 +7,14 @@
 (defun should-use-version (version)
   (should-have-env "NVM_BIN" (f-join nvm-dir version "bin"))
   (should-have-env "NVM_PATH" (f-join nvm-dir version "lib" "node"))
-  (should-have-env "PATH" (concat (f-full (f-join nvm-dir version "bin")) ":/path/to/foo/bin/:/path/to/bar/bin/")))
+  (should-have-env "PATH" (concat (f-full (f-join nvm-dir version "bin")) ":/path/to/foo/bin/:/path/to/bar/bin/"))
+  (should (string= (car exec-path) (f-join nvm-dir version "bin"))))
 
 (defun should-use-new-version (runtime version)
   (should-have-env "NVM_BIN" (f-join nvm-dir "versions" runtime version "bin"))
   (should-have-env "NVM_PATH" (f-join nvm-dir "versions" runtime version "lib" "node"))
-  (should-have-env "PATH" (concat (f-full (f-join nvm-dir "versions" runtime version "bin")) ":/path/to/foo/bin/:/path/to/bar/bin/")))
+  (should-have-env "PATH" (concat (f-full (f-join nvm-dir "versions" runtime version "bin")) ":/path/to/foo/bin/:/path/to/bar/bin/"))
+  (should (string= (car exec-path) (f-join nvm-dir "versions" runtime version "bin"))))
 
 (defun stub-old-tuples-for (versions)
   (let ((as-tuple (lambda (version)


### PR DESCRIPTION
Setting exec-path allows emacs to use the right node version when calling executables directly, not just through a shell (e.g., when using [tide](https://github.com/ananthakumaran/tide))