### PR TITLE
Add nvm-use-for-buffer function

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,12 @@ callback and then switch back to the previously used version.
 Read version from `.nvmrc` in `path` (or `default-directory`) and use
 that. Second `callback` argument is same as for `nvm-use`.
 
+### nvm-use-for-buffer `()`
+
+Call `nvm-use-for` on the file visited by the current buffer. Suitable
+for use in a mode hook to automatically activate the correct node
+version for a file.
+
 ## Contribution
 
 Contribution is much welcome!

--- a/nvm.el
+++ b/nvm.el
@@ -166,6 +166,15 @@ previously used version."
       (nvm-use (s-trim (f-read (f-expand ".nvmrc" nvmrc-path))) callback)
     (error "No .nvmrc found for %s" path)))
 
+;;;###autoload
+(defun nvm-use-for-buffer ()
+  "Activate Node based on an .nvmrc for the current file.
+If buffer is not visiting a file, do nothing."
+  (when buffer-file-name
+    (condition-case err
+        (nvm-use-for buffer-file-name)
+      (error (message "%s" err)))))
+
 (provide 'nvm)
 
 ;;; nvm.el ends here

--- a/test/nvm-test.el
+++ b/test/nvm-test.el
@@ -166,3 +166,34 @@
    (should (string= (car (nvm--find-exact-version-for "v0.8")) "v0.8.8"))
    (should (string= (car (nvm--find-exact-version-for "v0.10")) "v0.10.7"))
    (should (string= (car (nvm--find-exact-version-for "0.10")) "v0.10.7"))))
+
+;;;; nvm-use-for-buffer
+
+(ert-deftest nvm-use-for-buffer-not-visiting ()
+  (with-temp-buffer
+    ;; assert that there is no error:
+    (nvm-use-for-buffer)))
+
+(ert-deftest nvm-use-for-buffer-no-nvmrc ()
+  (with-sandbox
+   (stub nvm--installed-versions => (stub-old-tuples-for '("v0.8.2" "v0.10.1")))
+   (with-temp-buffer
+     (setq buffer-file-name (f-expand "test.js" nvm-test/sandbox-path))
+     ;; can't use should-use-version since we're not moving the node
+     ;; path to the front
+     (let ((old-path (getenv "PATH"))
+           (old-nvm-bin (getenv "NVM_BIN"))
+           (old-nvm-path (getenv "NVM_PATH")))
+       (nvm-use-for-buffer)
+       (should-have-env "NVM_BIN" old-nvm-bin)
+       (should-have-env "NVM_PATH" old-nvm-path)
+       (should-have-env "PATH" old-path)))))
+
+(ert-deftest nvm-use-for-buffer-with-nvmrc ()
+  (with-sandbox
+   (stub nvm--installed-versions => (stub-old-tuples-for '("v0.8.2" "v0.10.1")))
+   (with-temp-buffer
+     (setq buffer-file-name (f-expand "test.js" nvm-test/sandbox-path))
+     (write-nvmrc "v0.10.1")
+     (nvm-use-for-buffer)
+     (should-use-version "v0.10.1"))))


### PR DESCRIPTION
`nvm-use-for-buffer` is a wrapper around `nvm-use-for` that is suitable for use in mode hooks. I've been using this from my init.el, but I figured it was useful enough to upstream.

@rejeep Let me know if you have any objections to this; otherwise I'll plan to merge in about a week.