### PR TITLE
Initialize nvm-dir from environment if set

### DIFF
--- a/nvm.el
+++ b/nvm.el
@@ -50,7 +50,7 @@
 (defconst nvm-runtime-re
   "\\(?:versions/node/\\|versions/io.js/\\)?")
 
-(defcustom nvm-dir (f-full "~/.nvm")
+(defcustom nvm-dir (or (getenv "NVM_DIR") (f-full "~/.nvm"))
   "Full path to Nvm installation directory."
   :group 'nvm
   :type 'directory)


### PR DESCRIPTION
People who set `NVM_DIR` would usually prefer to have this respected over the default `~/.nvm`.  So let's help them one step :)