### PR TITLE
[Fix] Check if path is nil before comparing with node path regex

### DIFF
--- a/nvm.el
+++ b/nvm.el
@@ -135,7 +135,7 @@ previously used version."
                    new-bin-path
                    (-reject
                     (lambda (path)
-                      (s-matches? path-re path))
+                      (if path (s-matches? path-re path) t))
                     (parse-colon-path (getenv "PATH"))))))
             (setenv "PATH" (s-join path-separator paths))
             (setq exec-path (cons new-bin-path (--remove (s-matches? path-re it) exec-path))))

--- a/test/nvm-test.el
+++ b/test/nvm-test.el
@@ -38,6 +38,13 @@
    (nvm-use "v0.10.1")
    (should-use-version "v0.10.1")))
 
+(ert-deftest nvm-use-test/version-available-no-previous-trailing-colon-in-path ()
+  (with-sandbox
+   (setenv "PATH" "/path/to/foo/bin/:/path/to/bar/bin/:")
+   (stub nvm--installed-versions => (stub-old-tuples-for '("v0.10.1")))
+   (nvm-use "v0.10.1")
+   (should-use-version "v0.10.1")))
+
 (ert-deftest nvm-use-test/version-new-directory-style-no-callback ()
   (with-sandbox
    (stub nvm--installed-versions =>


### PR DESCRIPTION
If a user has a trailing colon in their path, the path will be parsed as a list ending with `nil`, which will cause `s-matches?` to throw an error. This change adds a `nil` check to the Lambda which walks the path and rejects entries which look like nvm entries, so it will also reject `nil` entries.