### PR TITLE
Drop dash-functional dependency

### DIFF
--- a/nvm.el
+++ b/nvm.el
@@ -7,7 +7,7 @@
 ;; Version: 0.3.0
 ;; Keywords: node, nvm
 ;; URL: http://github.com/rejeep/nvm.el
-;; Package-Requires: ((s "1.8.0") (dash "2.4.0") (f "0.14.0") (dash-functional "2.4.0"))
+;; Package-Requires: ((s "1.8.0") (dash "2.18.0") (f "0.14.0"))
 
 ;; This file is NOT part of GNU Emacs.
 
@@ -35,7 +35,6 @@
 (require 'f)
 (require 's)
 (require 'dash)
-(require 'dash-functional)
 
 (defgroup nvm nil
   "Manage Node versions within Emacs"


### PR DESCRIPTION
The Dash folks have [recently decided](https://github.com/magnars/dash.el/issues/356) to merge `dash-functional` into `dash`. The latest version of `dash-functional` now [emits a byte-code compilation warning when it is loaded](https://github.com/magnars/dash.el/pull/371/files#diff-d6aa2589d40457a508d26dcd01821248846d27f948782da8141dd0c71b98c6c7R47). 

Because `package.el` lacks a mechanism for specifying any constraints on dependency versions (apart from a minimum version) this means that any package depending on `nvm` will pick up the latest version of `dash-functional` and therefore print this warning. This breaks, for example, my package's [CI](https://github.com/jscheid/prettier.el/runs/1913983521?check_suite_focus=true#step:9:16).

This PR solves the problem by upgrading `dash` and dropping the `dash-functional` dependency.
